### PR TITLE
Use commit `title` instead of `initial version` for initial `spr` message

### DIFF
--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -525,7 +525,7 @@ async fn diff_impl(
             github_commit_message
                 .as_ref()
                 .map(|s| &s[..])
-                .unwrap_or("[𝘀𝗽𝗿] initial version"),
+                .unwrap_or(title),
             env!("CARGO_PKG_VERSION"),
         ),
         new_head_tree,


### PR DESCRIPTION
Use the actual commit title instead of `[𝘀𝗽𝗿] initial version` for the initial spr message. This is useful for instances where you are working in a repository with commit linting.

For example, if the repository requires that the first commit of each code change has a JIRA ticket in the commit message, the lint rule will fail.